### PR TITLE
add new rules TSLint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,27 @@
 
     // "no-any": true,
 
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
+
     // Temporarily relax rules
+    "semicolon": [true, "always"],
     "member-ordering": false,
     "variable-name": false,
     "no-empty": false,


### PR DESCRIPTION
-Semicolon required
-space before type

Добавил 2 правила для TSLint
-Точка запятой обязательна в конце;
- После двоеточия обязателен пробел 
varName: string  | линтер не ругается 
varName:string  | линтер ругается