### PR TITLE
limitation on character input

### DIFF
--- a/src/pages/calculator/calculator.html
+++ b/src/pages/calculator/calculator.html
@@ -11,9 +11,10 @@
             <ion-label stacked>{{'Send' | translate}}</ion-label>
             <ion-input
               [disabled]="!rates && calculationError"
-              type="number"
+              type="text"
               formControlName="sendAmount"
               OnlyNumber="true"
+              inputmode="decimals"
               required
             >
             </ion-input>
@@ -60,9 +61,10 @@
             <ion-label stacked>{{'Get' | translate}}</ion-label>
             <ion-input
               [disabled]="!rates && calculationError"
-              type="number"
+              type="text"
               formControlName="getAmount"
               OnlyNumber="true"
+              inputmode="decimals"
               required
             >
             </ion-input>


### PR DESCRIPTION
Проблема 
Можно вводить разные символы в поле инпут.

Поменял type= number на type = text. Теперь будет работать регулярка в form-controller. Т.к при type = number поле инпут возвращает пустую строку. И нельзя понять удалил ли пользователь значение в поле или ввел некорректное число. 

Но теперь может выводиться текстовая клавиатура пользователю. 
+ я добавил атрибут inputmode="decimals". Он сообщает браузеру, какая клавиатура должна выводиться. Не знаю будет ли работать в мобильном.
Есть в доке ionic, но работает ли в приложениях на мобилках - не понятно 
 https://ionicframework.com/docs/developing/keyboard 