### PR TITLE
fixed bug when resending the full amount of tokens after an unsuccess…

### DIFF
--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -162,7 +162,7 @@ export class ConfirmPage {
 
   private updateDestinationTag: any = data => {
     this.tx.destinationTag = data.value;
-  };
+  }
 
   ionViewDidLoad() {
     this.logger.info('Loaded: ConfirmPage');
@@ -348,7 +348,7 @@ export class ConfirmPage {
       this.wallet &&
       (this.wallet.network == network && this.wallet.coin == coin)
     ) {
-      return Promise.resolve();
+      return Promise.resolve(null);
     }
 
     this.wallets = this.profileProvider.getWallets({
@@ -365,7 +365,7 @@ export class ConfirmPage {
       const title = this.translate.instant('No wallets available');
       return Promise.reject({ msg, title });
     }
-    return Promise.resolve();
+    return Promise.resolve(null);
   }
 
   /* sets a wallet on the UI, creates a TXPs for that wallet */
@@ -511,7 +511,7 @@ export class ConfirmPage {
 
       // End of quick refresh, before wallet is selected.
       if (!wallet) {
-        return resolve();
+        return resolve(null);
       }
 
       this.onGoingProcessProvider.set('calculatingFee');
@@ -554,35 +554,45 @@ export class ConfirmPage {
             tx.feeLevelName = feeOpts[tx.feeLevel];
             tx.feeRate = feeRate;
           }
-
           // call getSendMaxInfo if was selected from amount view
           if (tx.sendMax && this.isChain()) {
             this.useSendMax(tx, wallet, opts)
               .then(() => {
-                return resolve();
+                return resolve(null);
               })
               .catch(err => {
                 return reject(err);
               });
-          } else if (tx.speedUpTx && this.isChain()) {
+          } 
+          else if (tx.sendMax) {
+            this.useSendMaxToken(tx, wallet, opts)
+              .then(() => {
+                return resolve(null);
+              })
+              .catch(err => {
+                return reject(err);
+              });
+          }
+          else if (tx.speedUpTx && this.isChain()) {
             this.speedUpTx(tx, wallet, opts)
               .then(() => {
-                return resolve();
+                return resolve(null);
               })
               .catch(err => {
                 return reject(err);
               });
-          } else {
+          } 
+          else {
             // txp already generated for this wallet?
             if (tx.txp[wallet.id]) {
               this.onGoingProcessProvider.clear();
-              return resolve();
+              return resolve(null);
             }
 
             this.buildTxp(tx, wallet, opts)
               .then(() => {
                 this.onGoingProcessProvider.clear();
-                return resolve();
+                return resolve(null);
               })
               .catch(err => {
                 this.onGoingProcessProvider.clear();
@@ -609,7 +619,7 @@ export class ConfirmPage {
               this.showErrorInfoSheet(
                 this.translate.instant('Not enough funds for fee')
               );
-              return resolve();
+              return resolve(null);
             }
             tx.sendMaxInfo = sendMaxInfo;
             tx.amount = tx.sendMaxInfo.amount;
@@ -618,12 +628,12 @@ export class ConfirmPage {
           this.showWarningSheet(wallet, sendMaxInfo);
           // txp already generated for this wallet?
           if (tx.txp[wallet.id]) {
-            return resolve();
+            return resolve(null);
           }
 
           this.buildTxp(tx, wallet, opts)
             .then(() => {
-              return resolve();
+              return resolve(null);
             })
             .catch(err => {
               return reject(err);
@@ -638,6 +648,29 @@ export class ConfirmPage {
     });
   }
 
+  private useSendMaxToken(tx, wallet, opts): Promise<void> {
+    return new Promise((resolve, reject) => {
+      tx.amount = this.getSendMaxAmountToken();
+      this.getAmountDetails();
+  
+      // txp already generated for this wallet?
+      if (tx.txp[wallet.id]) {
+        this.onGoingProcessProvider.clear();
+        return resolve(null);
+      }
+
+      this.buildTxp(tx, wallet, opts)
+        .then(() => {
+          this.onGoingProcessProvider.clear();
+          return resolve(null);
+        })
+        .catch(err => {
+          this.onGoingProcessProvider.clear();
+          return reject(err);
+        });
+    });
+  }
+
   public speedUpTx(tx, wallet, opts) {
     return this.getSpeedUpTxInfo(_.clone(tx), wallet)
       .then(speedUpTxInfo => {
@@ -648,7 +681,7 @@ export class ConfirmPage {
             this.showErrorInfoSheet(
               this.translate.instant('Not enough funds for fee')
             );
-            return Promise.resolve();
+            return Promise.resolve(null);
           }
           tx.speedUpTxInfo = speedUpTxInfo;
         }
@@ -719,7 +752,7 @@ export class ConfirmPage {
               ' Txp:' +
               txp.id
           );
-          return resolve();
+          return resolve(null);
         })
         .catch(err => {
           if (err.message == 'Insufficient funds') {
@@ -733,7 +766,7 @@ export class ConfirmPage {
 
   private getSendMaxInfo(tx, wallet): Promise<any> {
     return new Promise((resolve, reject) => {
-      if (!tx.sendMax) return resolve();
+      if (!tx.sendMax) return resolve(null);
 
       this.onGoingProcessProvider.set('retrievingInputs');
       this.walletProvider
@@ -754,8 +787,14 @@ export class ConfirmPage {
     });
   }
 
+  private getSendMaxAmountToken(): number {
+    let maxAmountToken = this.wallet.cachedStatus.availableBalanceSat;
+    
+    return maxAmountToken;
+  }
+
   private getSpeedUpTxInfo(tx, wallet): Promise<any> {
-    if (!tx.speedUpTx) return Promise.resolve();
+    if (!tx.speedUpTx) return Promise.resolve(null);
 
     this.onGoingProcessProvider.set('retrievingInputs');
     return this.walletProvider
@@ -1179,7 +1218,7 @@ export class ConfirmPage {
               return;
             }
             this.publishAndSign(txp, wallet);
-          })
+          });
       })
       .catch(err => {
         this.onGoingProcessProvider.clear();
@@ -1403,7 +1442,7 @@ export class ConfirmPage {
       clearCache: true,
       dryRun: true
     }).catch(err => {
-      this.showErrorInfoSheet(err)
+      this.showErrorInfoSheet(err);
       this.logger.warn('Error updateTx', err);
     });
   }


### PR DESCRIPTION
Проблема: 
Выбираю сумму отправки больше чем на балансе. Птм в модалке  выбираю sendMax. Если это нативная монета блокчейна, то все ок. Если токен, то ничего не происходит


Почему так? ln 558 Проверка на send Max и то что нативка. Если токен, то ничего не происходит.
 у нативной монеты. используется метод обьекта wallet.getSendMaxInfo (wallet.ts ln 2033). Который у него в прототипе. и он не выдает баланс токенов. Поэтому написал функцию аналогичную useSendMax без обращения к методу прототипа объекта wallet 