### PR TITLE
added privatePath field to txProp object | Deposit page

### DIFF
--- a/src/pages/deposit/deposit.ts
+++ b/src/pages/deposit/deposit.ts
@@ -18,6 +18,7 @@ interface TxProperties {
   user_duc_address: string;
   redeem_script: string;
   lock_time: number;
+  private_path: string;
 }
 
 @Component({
@@ -282,7 +283,8 @@ export class DepositPage {
         vout_number: deposit.extraData[0].txVout,
         user_duc_address: deposit.extraData[0].userDucAddress,
         redeem_script: deposit.extraData[0].redeemScript,
-        lock_time: deposit.extraData[0].lockTime
+        lock_time: deposit.extraData[0].lockTime,
+        private_path: deposit.extraData[0].privatePath
       };
           
       deposit.cltv_details = txProps;


### PR DESCRIPTION
wallet.ts 
если в SignFreeze передавали параметр AddressPath = false 
то на 1748 строчке возникала ошибка т.к data.private_path = undefind 

добавил параметр private_path в txProps который передается в signFreeze 